### PR TITLE
fix: check for errors on ElasticsearchClient

### DIFF
--- a/src/Kiss.Elastic.Sync/ElasticBulkClient.cs
+++ b/src/Kiss.Elastic.Sync/ElasticBulkClient.cs
@@ -30,16 +30,14 @@ namespace Kiss.Elastic.Sync
         {
             var handler = new HttpClientHandler();
             handler.ClientCertificateOptions = ClientCertificateOption.Manual;
-            handler.ServerCertificateCustomValidationCallback =
-                (httpRequestMessage, cert, cetChain, policyErrors) =>
-                {
-                    return true;
-                };
+            handler.ServerCertificateCustomValidationCallback = (a, b, c, d) => true;
             _httpClient = new HttpClient(handler);
             _httpClient.BaseAddress = baseUri;
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Helpers.EncodeCredential(username, password));
             var clientSettings = new ElasticsearchClientSettings(baseUri)
-                .Authentication(new BasicAuthentication(username, password));
+                .Authentication(new BasicAuthentication(username, password))
+                .ServerCertificateValidationCallback((a, b, c, d) => true);
+
             _elasticsearchClient = new ElasticsearchClient(clientSettings);
             _scrollPageSize = scrollPageSize;
         }
@@ -185,6 +183,11 @@ namespace Kiss.Elastic.Sync
                     .Scroll(scrollDuration),
                 token);
 
+            if (!searchResponse.IsSuccess())
+            {
+                throw new Exception("search failed: " + searchResponse.ToString());
+            }
+
             var scrollId = searchResponse.ScrollId;
             var hits = searchResponse.Hits;
 
@@ -200,7 +203,12 @@ namespace Kiss.Elastic.Sync
                     ScrollId = scrollId, 
                     Scroll = scrollDuration,
                 }, token);
-                
+
+                if (!scrollResponse.IsSuccess())
+                {
+                    throw new Exception("scroll failed: " + scrollResponse.ToString());
+                }
+
                 scrollId = scrollResponse.ScrollId;
                 hits = scrollResponse.Hits;
             }

--- a/src/Kiss.Elastic.Sync/ElasticBulkClient.cs
+++ b/src/Kiss.Elastic.Sync/ElasticBulkClient.cs
@@ -30,12 +30,14 @@ namespace Kiss.Elastic.Sync
         {
             var handler = new HttpClientHandler();
             handler.ClientCertificateOptions = ClientCertificateOption.Manual;
+            // skip checking the certificate because we run Elastic internally, with a local certificate
             handler.ServerCertificateCustomValidationCallback = (a, b, c, d) => true;
             _httpClient = new HttpClient(handler);
             _httpClient.BaseAddress = baseUri;
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Helpers.EncodeCredential(username, password));
             var clientSettings = new ElasticsearchClientSettings(baseUri)
                 .Authentication(new BasicAuthentication(username, password))
+                // skip checking the certificate because we run Elastic internally, with a local certificate
                 .ServerCertificateValidationCallback((a, b, c, d) => true);
 
             _elasticsearchClient = new ElasticsearchClient(clientSettings);


### PR DESCRIPTION
Elasticsearch draait intern op een zelfgegenereerd certificaat. Daarom skippen we de validatie van dat certificaat op de HttpClient. Dat moeten we ook op de ElasticsearchClient doen. Daarnaast checks toegevoegd of de calls via de ElasticsearchClient succesvol zijn.