### PR TITLE
Fix finding PC-2161: not all page content ends up in Elastic index

### DIFF
--- a/src/Kiss.Elastic.Sync/Sources/SharePointPageSourceClient.cs
+++ b/src/Kiss.Elastic.Sync/Sources/SharePointPageSourceClient.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Kiss.Elastic.Sync.SharePoint;
 
@@ -49,7 +49,7 @@ namespace Kiss.Elastic.Sync.Sources
             yield return new KissEnvelope(
                 Object: data,
                 Title: pageData.title,
-                ObjectMeta: pageData.content,
+                ObjectMeta: string.Join('\n', pageData.content),
                 Id: $"sharepoint_{pageData.id}",
                 Url: _pageUrl
             );


### PR DESCRIPTION
When indexing SharePoint pages, not all content ended up in Elastic because we only walked the canvasLayout structure and missed web parts that weren’t rendered there.

This change switches to using the page’s root webParts collection.

As a result, all visible content on a SharePoint page should now be included in the Elastic index, resolving PC-2161.