### PR TITLE
story PC-2085, task PC-2162: parse html so we can look up headings

### DIFF
--- a/src/Kiss.Elastic.Sync/Kiss.Elastic.Sync.csproj
+++ b/src/Kiss.Elastic.Sync/Kiss.Elastic.Sync.csproj
@@ -22,7 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="AngleSharp" Version="1.3.1" />
+    <PackageReference Include="Azure.Identity" Version="1.17.0" />
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.14.6" />
     <PackageReference Include="Microsoft.Graph" Version="5.87.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />

--- a/src/Kiss.Elastic.Sync/SharePoint/SharePointClient.cs
+++ b/src/Kiss.Elastic.Sync/SharePoint/SharePointClient.cs
@@ -1,4 +1,6 @@
-﻿using Azure.Identity;
+﻿using AngleSharp;
+using AngleSharp.Dom;
+using Azure.Identity;
 using Microsoft.Graph;
 using Microsoft.Graph.Models;
 
@@ -8,6 +10,7 @@ namespace Kiss.Elastic.Sync.SharePoint
     {
         private readonly GraphServiceClient _graphClient;
         private readonly string _siteIdentifier;
+        private readonly IBrowsingContext _context;
         private readonly string _siteUrl;
 
         public SharePointClient(string tenantId, string clientId, string clientSecret, string siteUrl)
@@ -16,6 +19,7 @@ namespace Kiss.Elastic.Sync.SharePoint
             _graphClient = new GraphServiceClient(credential);
             _siteUrl = siteUrl;
             _siteIdentifier = ParseSiteIdentifierFromUrl(siteUrl);
+            _context = BrowsingContext.New(Configuration.Default);
         }
 
         private static string ParseSiteIdentifierFromUrl(string siteUrl)
@@ -44,7 +48,7 @@ namespace Kiss.Elastic.Sync.SharePoint
                     .Sites[site.Id]
                     .Pages
                     .GraphSitePage
-                    .GetAsync(x=>
+                    .GetAsync(x =>
                     {
                         // we filteren nu nog op de url van de pagina. in de toekomst halen we alle pagina's bij een site op.
                         x.QueryParameters.Filter = $"webUrl eq '{pageUrl}'";
@@ -67,11 +71,25 @@ namespace Kiss.Elastic.Sync.SharePoint
             }
         }
 
-        public static IReadOnlyCollection<string> ExtractTextFromPage(SitePage sitePage) =>
-            GetWebParts(sitePage)
-                .SelectMany(GetHtml)
-                .Select(StripHtmlTags)
-                .ToHashSet();
+        public async Task<(IReadOnlyCollection<string> Content, IReadOnlyCollection<string> Headings)> ExtractTextFromPage(SitePage sitePage)
+        {
+            var allContent = new HashSet<string>();
+            var allHeadings = new HashSet<string>();
+            var allHtml = GetWebParts(sitePage)
+                .SelectMany(GetHtml);
+
+            foreach (var html in allHtml)
+            {
+                var (content, headings) = await ParseHtml(html);
+                allContent.Add(content);
+                foreach (var heading in headings)
+                {
+                    allHeadings.Add(heading);
+                }
+            }
+
+            return (allContent, allHeadings);
+        }
 
         private static IEnumerable<WebPart> GetWebParts(SitePage sitePage) =>
             sitePage.WebParts
@@ -86,7 +104,7 @@ namespace Kiss.Elastic.Sync.SharePoint
             }
 
             var additionalData = webPart.AdditionalData;
-            if (additionalData != null 
+            if (additionalData != null
                 && additionalData.TryGetValue("innerHtml", out var innerHtmlObj)
                 && innerHtmlObj?.ToString() is string innerHtml
                 && !string.IsNullOrWhiteSpace(innerHtml))
@@ -95,27 +113,55 @@ namespace Kiss.Elastic.Sync.SharePoint
             }
         }
 
-        private static string StripHtmlTags(string html)
+        private async Task<(string Content, IReadOnlyCollection<string> Headings)> ParseHtml(string html)
         {
             if (string.IsNullOrWhiteSpace(html))
-                return string.Empty;
+                return ("", []);
 
-            var text = System.Text.RegularExpressions.Regex.Replace(html, "<[^>]+>", " ");
+            using var doc = await _context.OpenAsync(req => req.Content(html));
 
-            text = text.Replace("&nbsp;", " ")
-                       .Replace("&amp;", "&")
-                       .Replace("&lt;", "<")
-                       .Replace("&gt;", ">")
-                       .Replace("&quot;", "\"");
+            var headings = doc.QuerySelectorAll("h1,h2,h3,h4,h5,h6")
+                .Select(x => x.TextContent)
+                .ToHashSet();
 
-            text = System.Text.RegularExpressions.Regex.Replace(text, @"\s+", " ");
+            var content = doc.ToHtml(MyMarkupFormatter.Instance).Trim();
 
-            return text.Trim();
+            return (content, headings);
         }
 
         public void Dispose()
         {
             _graphClient.Dispose();
+        }
+
+        private class MyMarkupFormatter : IMarkupFormatter
+        {
+            public static readonly IMarkupFormatter Instance = new MyMarkupFormatter();
+
+            private MyMarkupFormatter()
+            {
+                
+            }
+
+            public string CloseTag(IElement element, bool selfClosing) => "";
+
+            public string Comment(IComment comment) => "";
+
+            public string Doctype(IDocumentType doctype) => "";
+
+            public string LiteralText(ICharacterData text) => text.Data.Trim();
+
+            public string OpenTag(IElement element, bool selfClosing) => element.LocalName switch
+            {
+                "p" => "\n\n",
+                "br" => "\n",
+                "span" => " ",
+                _ => ""
+            };
+
+            public string Processing(IProcessingInstruction processing) => "";
+
+            public string Text(ICharacterData text) => text.Data.Trim();
         }
     }
 }

--- a/src/Kiss.Elastic.Sync/SharePoint/SharePointClient.cs
+++ b/src/Kiss.Elastic.Sync/SharePoint/SharePointClient.cs
@@ -124,7 +124,7 @@ namespace Kiss.Elastic.Sync.SharePoint
                 .Select(x => x.TextContent)
                 .ToHashSet();
 
-            var content = doc.ToHtml(MyMarkupFormatter.Instance).Trim();
+            var content = doc.ToHtml(TextWithWhitespaceFormatter.Instance).Trim();
 
             return (content, headings);
         }
@@ -135,11 +135,11 @@ namespace Kiss.Elastic.Sync.SharePoint
             _context.Dispose();
         }
 
-        private class MyMarkupFormatter : IMarkupFormatter
+        private class TextWithWhitespaceFormatter : IMarkupFormatter
         {
-            public static readonly IMarkupFormatter Instance = new MyMarkupFormatter();
+            public static readonly IMarkupFormatter Instance = new TextWithWhitespaceFormatter();
 
-            private MyMarkupFormatter()
+            private TextWithWhitespaceFormatter()
             {
                 
             }

--- a/src/Kiss.Elastic.Sync/SharePoint/SharePointClient.cs
+++ b/src/Kiss.Elastic.Sync/SharePoint/SharePointClient.cs
@@ -132,6 +132,7 @@ namespace Kiss.Elastic.Sync.SharePoint
         public void Dispose()
         {
             _graphClient.Dispose();
+            _context.Dispose();
         }
 
         private class MyMarkupFormatter : IMarkupFormatter

--- a/src/Kiss.Elastic.Sync/Sources/SharePointPageSourceClient.cs
+++ b/src/Kiss.Elastic.Sync/Sources/SharePointPageSourceClient.cs
@@ -32,12 +32,13 @@ namespace Kiss.Elastic.Sync.Sources
                 yield break;
             }
 
-            var content = SharePoint.SharePointClient.ExtractTextFromPage(page);
+            var (content, headings) = await _sharePointClient.ExtractTextFromPage(page);
             var pageData = new
             {
                 id = page.Id,
                 title = page.Title ?? "Geen titel",
-                content = content,
+                content,
+                headings,
                 url = _pageUrl,
                 lastModified = page.LastModifiedDateTime?.UtcDateTime ?? DateTime.UtcNow,
                 createdBy = page.CreatedBy?.User?.DisplayName,
@@ -49,7 +50,7 @@ namespace Kiss.Elastic.Sync.Sources
             yield return new KissEnvelope(
                 Object: data,
                 Title: pageData.title,
-                ObjectMeta: string.Join('\n', pageData.content),
+                ObjectMeta: "",
                 Id: $"sharepoint_{pageData.id}",
                 Url: _pageUrl
             );


### PR DESCRIPTION
Parse SharePoint page HTML so we can capture headings separately from the body text for later lookups.

We now:
- Use AngleSharp in `SharePointClient` to parse each web part’s HTML into a DOM
- Extract visible text plus a separate set of `h1`–`h6` headings from the page
- Change `ExtractTextFromPage` to return both `Content` and `Headings`
- Update `SharePointPageSourceClient` to use the new API and include both `content` and `headings` in the page data (while leaving `ObjectMeta` empty for now)
