### PR TITLE
fetch all pages recursively, including subsites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,80 @@
 # KISS-Elastic-Sync
 
 ## Introduction
+
 KISS offers the posibility to search for information within specific sources. This search functionality is using Elasticsearch. The KISS-Elastic-Sync-tool is used to create the necessary engines in a an Elasticsearch installation.
 
 Two types of sources are indexed in Elasticsearch to allow them to be easily searched from KISS:
+
 - Websites (by running this tool to set up a `crawler` in Enterprise Search)
 - Structured sources (by scheduling this tool to synchronize data from the source to an `index` in Elasticsearch)
 
 ## Run locally
+
 1. Make a copy of .env.local.example, rename it .env.local and fill in the required secrets.
 2. Set up a port forward for Enterprise Search, e.g.: `kubectl port-forward service/kiss-ent-http 3002`
 3. Set up a port forward for Elasticsearch, e.g.: `kubectl port-forward service/kiss-es-http 9200`
 4. Build the tool using docker-compose: `docker compose build`
-4. Run the tool using docker-compose: `docker compose --env-file ./.env.local run kiss.elastic.sync [ARGS...]`
+5. Run the tool using docker-compose: `docker compose --env-file ./.env.local run kiss.elastic.sync [ARGS...]`
 
 ## When you first set up a source
+
 This tool does the following automatically:
+
 1. Create a Enterprise Search `engine` for the source. For websites, a `crawler` is created and run. For structured sources, an `index` is created and linked to the `engine`.
 1. Create a `meta engine`. This is used to aggregate multiple sources. The `engine` from step 1 is linked to this `meta engine`.
 
 ## Relevance tuning
+
 You can use `Relevance tuning` from Kibana on the `meta engine`. See also the [KISS-documenation (in Dutch)](https://kiss-klantinteractie-servicesysteem.readthedocs.io/en/latest/CONFIGURATIE/#configuratie-van-elasticsearch-voor-kiss).
 
 ## Supported structured sources
+
 - SDG Producten
 - Medewerkers (Smoelenboek)
 - Vraag/antwoord combinaties (VAC)
 
 ## Commands
+
 Examples of how to schedule a cron job in Kubernetes with these arguments [can be found here](deploy)
 | Arguments | Description |
 | --- | --- |
 | No arguments | Sync SDG Producten |
 | `vac` | Sync VACs |
 | `smoelenboek` | Sync Medewerkers (Smoelenboek) |
+| `sharepoint` | Sync a Sharepoint Site, including all SubSites |
 | `domain https://www.mywebsite.nl` | Crawl the website https://www.mywebsite.nl |
 
-
 ## Environment variables
+
 ### Variables for the Elastic stack
-| Variable | Description |
-| --- | --- |
-| ELASTIC_BASE_URL | Base url for Elasticsearch |
-| ELASTIC_USERNAME | Username to log in to Elasticsearch. This can be the default root user `elastic` or a dedicated user you've created yourself |
-| ELASTIC_PASSWORD | Password for the username above. If you're using [ECK](https://www.elastic.co/guide/en/cloud-on-k8s/2.8/k8s-overview.html), you can find the password for the default user using the command `kubectl get secret kiss-es-elastic-user -o go-template='{{.data.elastic | base64decode}}'` |
-| ENTERPRISE_SEARCH_BASE_URL | Base url for Enterprise Search. This url is different from the Elasticsearch url |
-| ENTERPRISE_SEARCH_ENGINE | The name of the `meta-engine` that will be used |
-| ENTERPRISE_SEARCH_PRIVATE_API_KEY | An API key to maintain the `engine`s. You can find this in Kibana at the url `app/enterprise_search/app_search/credentials` |
+
+| Variable                          | Description                                                                                                                                                                                                                                                           |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| ELASTIC_BASE_URL                  | Base url for Elasticsearch                                                                                                                                                                                                                                            |
+| ELASTIC_USERNAME                  | Username to log in to Elasticsearch. This can be the default root user `elastic` or a dedicated user you've created yourself                                                                                                                                          |
+| ELASTIC_PASSWORD                  | Password for the username above. If you're using [ECK](https://www.elastic.co/guide/en/cloud-on-k8s/2.8/k8s-overview.html), you can find the password for the default user using the command `kubectl get secret kiss-es-elastic-user -o go-template='{{.data.elastic | base64decode}}'` |
+| ENTERPRISE_SEARCH_BASE_URL        | Base url for Enterprise Search. This url is different from the Elasticsearch url                                                                                                                                                                                      |
+| ENTERPRISE_SEARCH_ENGINE          | The name of the `meta-engine` that will be used                                                                                                                                                                                                                       |
+| ENTERPRISE_SEARCH_PRIVATE_API_KEY | An API key to maintain the `engine`s. You can find this in Kibana at the url `app/enterprise_search/app_search/credentials`                                                                                                                                           |
 
 ### Variables for the different sources
-| Variable | Description |
-| --- | --- |
-| SDG_OBJECTEN_BASE_URL | The base url for the Objects API to retrieve Producten |
-| SDG_OBJECT_TYPE_URL | The full url of the object type for Producten |
-| SDG_OBJECTEN_TOKEN | The token to connect to the Objects API to retrieve Producten |
-| MEDEWERKER_OBJECTEN_BASE_URL | The base url for the Objects API to retrieve mededewerkers (smoelenboek), or the PodiumD Adapter if applicable |
-| MEDEWERKER_OBJECT_TYPE_URL | The full url of the object type for medewerkers (smoelenboek) |
-| MEDEWERKER_OBJECTEN_TOKEN | The token to connect to the Objects API to retrieve medewerkers (smoelenboek). Use this if you are NOT using the PodiumD Adapter |
-| MEDEWERKER_OBJECTEN_CLIENT_ID | The client id to generate a JWT to connect to the PodiumD Adapter to retrieve medewerkers (smoelenboek). This has to match a setting in the PodiumD Adapter |
+
+| Variable                          | Description                                                                                                                                                     |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SDG_OBJECTEN_BASE_URL             | The base url for the Objects API to retrieve Producten                                                                                                          |
+| SDG_OBJECT_TYPE_URL               | The full url of the object type for Producten                                                                                                                   |
+| SDG_OBJECTEN_TOKEN                | The token to connect to the Objects API to retrieve Producten                                                                                                   |
+| MEDEWERKER_OBJECTEN_BASE_URL      | The base url for the Objects API to retrieve mededewerkers (smoelenboek), or the PodiumD Adapter if applicable                                                  |
+| MEDEWERKER_OBJECT_TYPE_URL        | The full url of the object type for medewerkers (smoelenboek)                                                                                                   |
+| MEDEWERKER_OBJECTEN_TOKEN         | The token to connect to the Objects API to retrieve medewerkers (smoelenboek). Use this if you are NOT using the PodiumD Adapter                                |
+| MEDEWERKER_OBJECTEN_CLIENT_ID     | The client id to generate a JWT to connect to the PodiumD Adapter to retrieve medewerkers (smoelenboek). This has to match a setting in the PodiumD Adapter     |
 | MEDEWERKER_OBJECTEN_CLIENT_SECRET | The client secret to generate a JWT to connect to the PodiumD Adapter to retrieve medewerkers (smoelenboek). This has to match a setting in the PodiumD Adapter |
-| VAC_OBJECTEN_BASE_URL | The base url for the Objects API to retrieve VACs |
-| VAC_OBJECT_TYPE_URL | The full url of the object type for VACs |
-| VAC_OBJECTEN_TOKEN | The token to connect to the Objects API to retrieve VACs |
+| VAC_OBJECTEN_BASE_URL             | The base url for the Objects API to retrieve VACs                                                                                                               |
+| VAC_OBJECT_TYPE_URL               | The full url of the object type for VACs                                                                                                                        |
+| VAC_OBJECTEN_TOKEN                | The token to connect to the Objects API to retrieve VACs                                                                                                        |
+| SHAREPOINT_TENANT_ID              | The Azure AD tenant id for the SharePoint app registration (GUID). Example: bd7f67dd-fc8c-4a9d-a1aa-c2e4d687b18f                                                |
+| SHAREPOINT_CLIENT_ID              | The client id (application id) of the SharePoint app registration. Example: 0166786a-df05-4e1c-a75c-7c3317002ad8                                                |
+| SHAREPOINT_CLIENT_SECRET          | The client secret for the SharePoint app registration (sensitive).                                                                                              |
+| SHAREPOINT_SITE_URL               | The full SharePoint site URL to crawl/sync. Example: https://my-tenant.sharepoint.com/sites/my-site                                                             |
+| SHAREPOINT_SOURCE_NAME            | A human-friendly name for the SharePoint source, which will show up in the checkboxes in the search bar in KISS. Example: ICATT Sharepoint Test Site            |

--- a/deploy/cronjob-sharepoint.yaml
+++ b/deploy/cronjob-sharepoint.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: kiss-elastic-sync-job-sharepoint
+  name: kiss-elastic-sync-job-my-sharepoint
 spec:
   schedule: "*/59 * * * *"
   jobTemplate:
@@ -9,24 +9,26 @@ spec:
       template:
         spec:
           containers:
-          - name: kiss-elastic-sync
-            image: ghcr.io/klantinteractie-servicesysteem/kiss-elastic-sync
-            imagePullPolicy: Always
-            args:
-            - sharepoint
-            env:
-            - name: SHAREPOINT_PAGE_URL
-              value: "https://icattnl.sharepoint.com/sites/synctooltestsite/SitePages/SyncTool-test-pagina.aspx"
-            envFrom:
-            - secretRef:
-                name: kiss-secrets
-            - configMapRef:
-                name: kiss-config
-            securityContext:
-              allowPrivilegeEscalation: false
-              runAsNonRoot: true
-              readOnlyRootFilesystem: true
-              runAsUser: 10000
-              capabilities:
-                drop: [ALL]
+            - name: kiss-elastic-sync
+              image: ghcr.io/klantinteractie-servicesysteem/kiss-elastic-sync
+              imagePullPolicy: Always
+              args:
+                - sharepoint
+              env:
+                - name: SHAREPOINT_SOURCE_NAME
+                  value: "My Sharepoint Test Site"
+                - name: SHAREPOINT_SITE_URL
+                  value: https://my-tenant.sharepoint.com/sites/my-site
+              envFrom:
+                - secretRef:
+                    name: my-secrets
+                - configMapRef:
+                    name: my-config
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                readOnlyRootFilesystem: true
+                runAsUser: 10000
+                capabilities:
+                  drop: [ALL]
           restartPolicy: Never

--- a/src/Kiss.Elastic.Sync/ElasticBulkClient.cs
+++ b/src/Kiss.Elastic.Sync/ElasticBulkClient.cs
@@ -60,16 +60,11 @@ namespace Kiss.Elastic.Sync
             return new ElasticBulkClient(elasticBaseUri, username, password);
         }
 
-        public async Task<string> IndexBulk(IAsyncEnumerable<KissEnvelope> envelopes, string bron, IReadOnlyList<string> completionFields, CancellationToken token)
-        {
-            const string Prefix = "search-";
-            var indexName = string.Create(bron.Length + Prefix.Length, bron, (a, b) =>
-            {
-                Prefix.CopyTo(a);
-                b.AsSpan().ToLowerInvariant(a[Prefix.Length..]);
-            });
 
-            if (!await EnsureIndex(bron, indexName, completionFields, token)) return indexName;
+
+        public async Task IndexBulk(IAsyncEnumerable<KissEnvelope> envelopes, string bron, string indexName, IReadOnlyList<string> completionFields, CancellationToken token)
+        {
+            if (!await EnsureIndex(bron, indexName, completionFields, token)) return;
 
             var existingIds = await GetExistingIds(indexName, token);
 
@@ -115,8 +110,6 @@ namespace Kiss.Elastic.Sync
                 using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token);
                 await Helpers.LogResponse(response, token);
             }
-
-            return indexName;
         }
 
         public async Task<bool> UpdateMappingForCrawlEngine(CancellationToken token)

--- a/src/Kiss.Elastic.Sync/Helpers.cs
+++ b/src/Kiss.Elastic.Sync/Helpers.cs
@@ -3,10 +3,11 @@ using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 
 namespace Kiss.Elastic.Sync
 {
-    public static class Helpers
+    public static partial class Helpers
     {
         public const string CompletionField = "_completion_all";
         public const string CrawlEngineName = "engine-crawler";
@@ -78,5 +79,17 @@ namespace Kiss.Elastic.Sync
             request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
             return await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token);
         }
+
+        public static string GenerateValidIndexName(string input)
+        {
+            var escaped = EscapeElasticsearchRegex()
+                .Replace(input, "-")
+                .ToLowerInvariant();
+
+            return $"search-{escaped}";
+        }
+
+        [GeneratedRegex("""[?|*|<|>|"| |\\|/|,|\|]+""")]
+        private static partial Regex EscapeElasticsearchRegex();
     }
 }

--- a/src/Kiss.Elastic.Sync/Program.cs
+++ b/src/Kiss.Elastic.Sync/Program.cs
@@ -29,13 +29,11 @@ if (args.Length == 2 && args[0] == "domain")
     return;
 }
 
-var source = args.FirstOrDefault();
-
-
-using var sourceClient = SourceFactory.CreateClient(source);
+using var sourceClient = SourceFactory.CreateClient(args);
 Console.WriteLine("Start syncing source " + sourceClient.Source);
+var indexName = Helpers.GenerateValidIndexName(sourceClient.Source);
 
 var records = sourceClient.Get(cancelSource.Token);
-var indexName = await elasticClient.IndexBulk(records, sourceClient.Source, sourceClient.CompletionFields, cancelSource.Token);
+await elasticClient.IndexBulk(records, sourceClient.Source, indexName, sourceClient.CompletionFields, cancelSource.Token);
 await enterpriseClient.AddIndexEngineAsync(indexName, cancelSource.Token);
 Console.WriteLine("Finished indexing source " + sourceClient.Source);

--- a/src/Kiss.Elastic.Sync/SharePoint/SharePointClient.cs
+++ b/src/Kiss.Elastic.Sync/SharePoint/SharePointClient.cs
@@ -33,11 +33,13 @@ namespace Kiss.Elastic.Sync.SharePoint
 
         public async IAsyncEnumerable<SitePage> GetAllPages([EnumeratorCancellation] CancellationToken token)
         {
+            // Check site via Graph API lookup (GUID is nodig om paginas en subsites op te halen)
             var rootSite = await _graphClient.Sites[_siteIdentifier].GetAsync(cancellationToken: token);
             if (rootSite == null)
             {
                 yield break;
             }
+            // Haal alle sites op met GUID
             await foreach (var subSite in GetAllSitesRecursive(rootSite, token))
             {
                 await foreach (var page in GetAllPages(subSite, token))

--- a/src/Kiss.Elastic.Sync/SharePoint/SharePointClient.cs
+++ b/src/Kiss.Elastic.Sync/SharePoint/SharePointClient.cs
@@ -70,11 +70,15 @@ namespace Kiss.Elastic.Sync.SharePoint
         }
 
         /// <summary>
-        /// 
+        /// Enumerates the specified site and all of its descendant sub-sites recursively.
         /// </summary>
-        /// <param name="root"></param>
-        /// <param name="token"></param>
-        /// <returns></returns>
+        /// <remarks>Enumeration is performed in a depth-first manner. The returned sequence includes the
+        /// root site as the first element, followed by all sub-sites recursively. If cancellation is requested via
+        /// <paramref name="token"/>, the enumeration will be stopped.</remarks>
+        /// <param name="root">The root <see cref="Site"/> from which to begin the recursive enumeration. Cannot be null.</param>
+        /// <param name="token">A cancellation token that can be used to cancel the asynchronous enumeration.</param>
+        /// <returns>An asynchronous sequence of <see cref="Site"/> objects, including the root site and all sub-sites in the
+        /// hierarchy.</returns>
         private async IAsyncEnumerable<Site> GetAllSitesRecursive(Site root, [EnumeratorCancellation] CancellationToken token)
         {
             yield return root;

--- a/src/Kiss.Elastic.Sync/Sources/SharePointPageSourceClient.cs
+++ b/src/Kiss.Elastic.Sync/Sources/SharePointPageSourceClient.cs
@@ -4,9 +4,9 @@ using Kiss.Elastic.Sync.SharePoint;
 
 namespace Kiss.Elastic.Sync.Sources
 {
-    public sealed class SharePointPageSourceClient(SharePointClient sharePointClient) : IKissSourceClient
+    public sealed class SharePointPageSourceClient(SharePointClient sharePointClient, string source) : IKissSourceClient
     {
-        public string Source => "SharePoint";
+        public string Source => source;
 
         public IReadOnlyList<string> CompletionFields { get; } = new[]
         {

--- a/src/Kiss.Elastic.Sync/Sources/SharePointPageSourceClient.cs
+++ b/src/Kiss.Elastic.Sync/Sources/SharePointPageSourceClient.cs
@@ -4,11 +4,8 @@ using Kiss.Elastic.Sync.SharePoint;
 
 namespace Kiss.Elastic.Sync.Sources
 {
-    public sealed class SharePointPageSourceClient : IKissSourceClient
+    public sealed class SharePointPageSourceClient(SharePointClient sharePointClient) : IKissSourceClient
     {
-        private readonly SharePointClient _sharePointClient;
-        private readonly string _pageUrl;
-
         public string Source => "SharePoint";
 
         public IReadOnlyList<string> CompletionFields { get; } = new[]
@@ -17,50 +14,40 @@ namespace Kiss.Elastic.Sync.Sources
             "content"
         };
 
-        public SharePointPageSourceClient(SharePointClient sharePointClient, string pageUrl)
-        {
-            _sharePointClient = sharePointClient;
-            _pageUrl = pageUrl;
-        }
-
         public async IAsyncEnumerable<KissEnvelope> Get([EnumeratorCancellation] CancellationToken token)
         {
-            var page = await _sharePointClient.GetPageByUrl(_pageUrl, token);
-
-            if (page == null)
+            await foreach (var page in sharePointClient.GetAllPages(token))
             {
-                yield break;
+                var (content, headings) = await sharePointClient.ExtractTextFromPage(page);
+                var pageData = new
+                {
+                    id = page.Id,
+                    title = page.Title ?? "Geen titel",
+                    content,
+                    headings,
+                    url = page.WebUrl,
+                    lastModified = page.LastModifiedDateTime?.UtcDateTime ?? DateTime.UtcNow,
+                    createdBy = page.CreatedBy?.User?.DisplayName,
+                    lastModifiedBy = page.LastModifiedBy?.User?.DisplayName
+                };
+
+                var data = JsonSerializer.SerializeToElement(pageData);
+
+                yield return new KissEnvelope(
+                    Object: data,
+                    Title: pageData.title,
+                    ObjectMeta: "",
+                    Id: $"sharepoint_{pageData.id}",
+                    Url: page.WebUrl
+                );
+
+                Console.WriteLine($"Page indexed: {pageData.title}");
             }
-
-            var (content, headings) = await _sharePointClient.ExtractTextFromPage(page);
-            var pageData = new
-            {
-                id = page.Id,
-                title = page.Title ?? "Geen titel",
-                content,
-                headings,
-                url = _pageUrl,
-                lastModified = page.LastModifiedDateTime?.UtcDateTime ?? DateTime.UtcNow,
-                createdBy = page.CreatedBy?.User?.DisplayName,
-                lastModifiedBy = page.LastModifiedBy?.User?.DisplayName
-            };
-
-            var data = JsonSerializer.SerializeToElement(pageData);
-
-            yield return new KissEnvelope(
-                Object: data,
-                Title: pageData.title,
-                ObjectMeta: "",
-                Id: $"sharepoint_{pageData.id}",
-                Url: _pageUrl
-            );
-
-            Console.WriteLine($"Page indexed: {pageData.title}");
         }
 
         public void Dispose()
         {
-            _sharePointClient?.Dispose();
+            sharePointClient?.Dispose();
         }
     }
 }

--- a/src/Kiss.Elastic.Sync/Sources/SourceFactory.cs
+++ b/src/Kiss.Elastic.Sync/Sources/SourceFactory.cs
@@ -70,11 +70,10 @@
             var clientId = Helpers.GetRequiredEnvironmentVariable("SHAREPOINT_CLIENT_ID");
             var clientSecret = Helpers.GetRequiredEnvironmentVariable("SHAREPOINT_CLIENT_SECRET");
             var siteUrl = Helpers.GetRequiredEnvironmentVariable("SHAREPOINT_SITE_URL");
-            var pageUrl = Helpers.GetRequiredEnvironmentVariable("SHAREPOINT_PAGE_URL");
 
             var sharePointClient = new SharePoint.SharePointClient(tenantId, clientId, clientSecret, siteUrl);
 
-            return new SharePointPageSourceClient(sharePointClient, pageUrl);
+            return new SharePointPageSourceClient(sharePointClient);
         }
     }
 }

--- a/src/Kiss.Elastic.Sync/Sources/SourceFactory.cs
+++ b/src/Kiss.Elastic.Sync/Sources/SourceFactory.cs
@@ -2,7 +2,7 @@
 {
     public static class SourceFactory
     {
-        public static IKissSourceClient CreateClient(string? source) => (source?.ToLowerInvariant()) switch
+        public static IKissSourceClient CreateClient(string[]? args) => (args?.FirstOrDefault()?.ToLowerInvariant()) switch
         {
             "vac" => GetVacClient(),
             "smoelenboek" => GetMedewerkerClient(),
@@ -70,10 +70,11 @@
             var clientId = Helpers.GetRequiredEnvironmentVariable("SHAREPOINT_CLIENT_ID");
             var clientSecret = Helpers.GetRequiredEnvironmentVariable("SHAREPOINT_CLIENT_SECRET");
             var siteUrl = Helpers.GetRequiredEnvironmentVariable("SHAREPOINT_SITE_URL");
+            var sourceName = Helpers.GetRequiredEnvironmentVariable("SHAREPOINT_SOURCE_NAME");
 
             var sharePointClient = new SharePoint.SharePointClient(tenantId, clientId, clientSecret, siteUrl);
 
-            return new SharePointPageSourceClient(sharePointClient);
+            return new SharePointPageSourceClient(sharePointClient, sourceName);
         }
     }
 }

--- a/test/Kiss.Elastic.Sync.IntegrationTest/ElasticBulkClientTests.cs
+++ b/test/Kiss.Elastic.Sync.IntegrationTest/ElasticBulkClientTests.cs
@@ -8,8 +8,8 @@ namespace Kiss.Elastic.Sync.IntegrationTest
 {
     public class ElasticBulkClientTests(ElasticFixture fixture) : IClassFixture<ElasticFixture>
     {
-        const string IndexWithoutPrefix = "my_index";
-        const string IndexWithPrefix = $"search-{IndexWithoutPrefix}";
+        const string SourceName = "my_index";
+        static readonly string s_indexName = Helpers.GenerateValidIndexName(SourceName);
 
         [Fact]
         public async Task Bulk_insert_works_for_inserts_updates_and_deletes()
@@ -51,12 +51,12 @@ namespace Kiss.Elastic.Sync.IntegrationTest
                 .Select(Map)
                 .AsAsyncEnumerable();
 
-            await bulkClient.IndexBulk(envelopes, IndexWithoutPrefix, [], default);
+            await bulkClient.IndexBulk(envelopes, SourceName, s_indexName, [], default);
 
-            var refreshResponse = await elastic.Indices.RefreshAsync(IndexWithPrefix);
+            var refreshResponse = await elastic.Indices.RefreshAsync(s_indexName);
             Assert.True(refreshResponse.IsSuccess());
 
-            var searchResponse = await elastic.SearchAsync<KissEnvelope>(IndexWithPrefix);
+            var searchResponse = await elastic.SearchAsync<KissEnvelope>(s_indexName);
             Assert.True(searchResponse.IsSuccess());
 
             var actualRecords = searchResponse.Hits.ToDictionary(x => x.Id!, x => x.Source.Title!);


### PR DESCRIPTION
Change SharePoint indexing from “single configured page” to “**all pages on the site and its subsites**”.

We now:
- Recursively traverse all sites/subsites via Microsoft Graph  
- Use a generic iterator to stream all paginated pages  
- Emit a `KissEnvelope` for each page with content, headings, URL and metadata  
- Drop the `SHAREPOINT_PAGE_URL` env var and simplify `SourceFactory` / `SharePointPageSourceClient` construction.