### PR TITLE
Support hub sites and classic pages

### DIFF
--- a/src/Kiss.Elastic.Sync/SharePoint/SharePointClient.cs
+++ b/src/Kiss.Elastic.Sync/SharePoint/SharePointClient.cs
@@ -135,6 +135,18 @@ namespace Kiss.Elastic.Sync.SharePoint
             }
         }
 
+        /// <summary>
+        /// Asynchronously retrieves all sites and subsites related to the specified SharePoint hub site, excluding the
+        /// root site itself.
+        /// </summary>
+        /// <remarks>This method queries for sites that share the same DepartmentId (SiteId) as the root
+        /// hub site. The root site itself is not included in the results. The enumeration is performed asynchronously
+        /// and supports cancellation.</remarks>
+        /// <param name="rootSite">The root SharePoint site representing the hub. Must have a valid SharePoint SiteId in its SharepointIds
+        /// property.</param>
+        /// <param name="token">A cancellation token that can be used to cancel the asynchronous operation.</param>
+        /// <returns>An asynchronous stream of Site objects representing all sites and subsites associated with the specified hub
+        /// site, excluding the root site. The stream is empty if the root site does not have a valid SiteId.</returns>
         private async IAsyncEnumerable<Site> GetAllHubRelatedSitesAndSubSites(Site rootSite, [EnumeratorCancellation] CancellationToken token)
         {
             // Hub-related sites are discovered by searching for the hub's DepartmentId (which is its SiteId)

--- a/src/Kiss.Elastic.Sync/SharePoint/SharePointClient.cs
+++ b/src/Kiss.Elastic.Sync/SharePoint/SharePointClient.cs
@@ -113,6 +113,16 @@ namespace Kiss.Elastic.Sync.SharePoint
         private static bool IsSubsite(Site site) =>
             !string.IsNullOrWhiteSpace(site?.ParentReference?.SiteId);
 
+        /// <summary>
+        /// Recursively retrieves all descendant sub-sites of the specified root site as an asynchronous stream.
+        /// </summary>
+        /// <remarks>Enumeration is performed recursively and may result in a large number of results if
+        /// the site hierarchy is deep. The operation is performed lazily; sub-sites are retrieved as the stream is
+        /// enumerated. The caller is responsible for handling cancellation via the provided token.</remarks>
+        /// <param name="root">The root <see cref="Site"/> from which to begin retrieving sub-sites. Cannot be null.</param>
+        /// <param name="token">A cancellation token that can be used to cancel the asynchronous operation.</param>
+        /// <returns>An asynchronous stream of <see cref="Site"/> objects representing all sub-sites under the specified root,
+        /// including nested descendants. The stream is empty if the root has no sub-sites.</returns>
         private async IAsyncEnumerable<Site> GetAllSubSitesRecursive(Site root, [EnumeratorCancellation] CancellationToken token)
         {
             await foreach (var site in GetAllSubSites(root, token))

--- a/src/Kiss.Elastic.Sync/SharePoint/SharePointPage.cs
+++ b/src/Kiss.Elastic.Sync/SharePoint/SharePointPage.cs
@@ -1,0 +1,13 @@
+﻿namespace Kiss.Elastic.Sync.SharePoint;
+
+public record SharePointPage
+{
+    public required string Id { get; init; }
+    public required string Title { get; init; }
+    public required IReadOnlyCollection<string> Content { get; init; }
+    public required IReadOnlyCollection<string> Headings { get; init; }
+    public required string? Url { get; init; }
+    public required DateTimeOffset? LastModified { get; init; }
+    public required string? CreatedBy { get; init; }
+    public required string? LastModifiedBy { get; init; }
+}


### PR DESCRIPTION
Zwolle has Hubsites with related sites in Sharepoint, which is different from a parent / child site relationship.
Haarlemmermeer has Classic Sharepoint pages, which are different than modern/site pages.
We need to support both.